### PR TITLE
Add resolve at the last

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -57,4 +57,4 @@ compare({
   json,
   urlPrefix,
   threshold,
-});
+}).catch(() => process.exit(1));

--- a/src/index.js
+++ b/src/index.js
@@ -167,20 +167,19 @@ module.exports = (params: Params) => new Promise((resolve, reject) => {
         cleanupExpectedDir(expectedImages, expectedDir);
         copyImages(actualImages, dirs).then(() => {
           log.success(`\nAll images are updated. `);
-          resolve(result);
         })
       } else {
         // TODO: add fail option
         if (failed.length > 0 /* || newImages.length > 0 || deletedImages.length > 0 */) {
           log.fail(`\nInspect your code changes, re-run with \`-U\` to update them. `);
-          if (!ignoreChange) process.exit(1);
-          return;
+          if (!ignoreChange) return Promise.reject();
         }
       }
+      resolve(result);
     })
     .catch(err => {
       log.fail(err);
-      process.exit(1);
+      return Promise.reject(err);
     });
 });
 


### PR DESCRIPTION
Hi. I'm attempting to call this module's `compare` function from other module, however it seems that sometimes this func is never resolved.
And I think manipulation of `process` or exit code could be put together into `cli.js` rather than `index.js` because it has strong side-effect.