### PR TITLE
set block style to .ui.link style explicitly

### DIFF
--- a/report/src/views/ItemSummaries.vue
+++ b/report/src/views/ItemSummaries.vue
@@ -31,4 +31,7 @@ module.exports = {
 .summary {
     margin: 5px 20px 20px;
 }
+.link {
+    display: block;
+}
 </style>


### PR DESCRIPTION
Hi. It seems that `summary a.ui.link` 's style is broken.

[![https://gyazo.com/5d43792febd8836793715096c5a8d608](https://i.gyazo.com/5d43792febd8836793715096c5a8d608.png)](https://gyazo.com/5d43792febd8836793715096c5a8d608)

This PR fix it.